### PR TITLE
Improved creation of `I2pListener`s

### DIFF
--- a/src/net/datagram.rs
+++ b/src/net/datagram.rs
@@ -3,6 +3,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use crate::error::{Error, ErrorKind};
 use crate::net::{I2pSocketAddr, ToI2pSocketAddrs};
 use crate::sam::DEFAULT_API;
+use crate::sam_options::SAMOptions;
 
 /// Unimplemented
 ///
@@ -51,19 +52,21 @@ impl I2pDatagramSocket {
 	/// let socket = I2pDatagramSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
 	/// ```
 	pub fn bind<A: ToI2pSocketAddrs>(addr: A) -> Result<I2pDatagramSocket, Error> {
-		I2pDatagramSocket::bind_via(DEFAULT_API, addr)
+		I2pDatagramSocket::bind_via(DEFAULT_API, addr, &SAMOptions::default())
 	}
 
 	pub fn bind_via<A: ToSocketAddrs, B: ToI2pSocketAddrs>(
 		sam_addr: A,
 		addr: B,
+		options: &SAMOptions
 	) -> Result<I2pDatagramSocket, Error> {
-		super::each_i2p_addr(sam_addr, addr, I2pDatagramSocket::bind_addr).map_err(|e| e.into())
+		super::each_i2p_addr(sam_addr, addr, options,I2pDatagramSocket::bind_addr).map_err(|e| e.into())
 	}
 
 	fn bind_addr(
 		_sam_addr: &SocketAddr,
 		_addr: &I2pSocketAddr,
+		_options: &SAMOptions
 	) -> Result<I2pDatagramSocket, Error> {
 		unimplemented!();
 	}
@@ -175,15 +178,16 @@ impl I2pDatagramSocket {
 	/// socket.connect("127.0.0.1:8080").expect("connect function failed");
 	/// ```
 	pub fn connect<A: ToI2pSocketAddrs>(&self, addr: A) -> Result<(), Error> {
-		self.connect_via(DEFAULT_API, addr)
+		self.connect_via(DEFAULT_API, addr, &SAMOptions::default())
 	}
 
 	pub fn connect_via<A: ToSocketAddrs, B: ToI2pSocketAddrs>(
 		&self,
 		sam_addr: A,
 		addr: B,
+		options: &SAMOptions,
 	) -> Result<(), Error> {
-		super::each_i2p_addr(sam_addr, addr, |_sam_addr, _addr| unimplemented!())
+		super::each_i2p_addr(sam_addr, addr, options, |_sam_addr, _addr, _opts| unimplemented!())
 	}
 
 	/// Sends data on the socket to the remote address to which it is connected.

--- a/src/net/datagram.rs
+++ b/src/net/datagram.rs
@@ -52,13 +52,13 @@ impl I2pDatagramSocket {
 	/// let socket = I2pDatagramSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
 	/// ```
 	pub fn bind<A: ToI2pSocketAddrs>(addr: A) -> Result<I2pDatagramSocket, Error> {
-		I2pDatagramSocket::bind_via(DEFAULT_API, addr, &SAMOptions::default())
+		I2pDatagramSocket::bind_via(DEFAULT_API, addr, SAMOptions::default())
 	}
 
 	pub fn bind_via<A: ToSocketAddrs, B: ToI2pSocketAddrs>(
 		sam_addr: A,
 		addr: B,
-		options: &SAMOptions
+		options: SAMOptions
 	) -> Result<I2pDatagramSocket, Error> {
 		super::each_i2p_addr(sam_addr, addr, options,I2pDatagramSocket::bind_addr).map_err(|e| e.into())
 	}
@@ -66,7 +66,7 @@ impl I2pDatagramSocket {
 	fn bind_addr(
 		_sam_addr: &SocketAddr,
 		_addr: &I2pSocketAddr,
-		_options: &SAMOptions
+		_options: SAMOptions
 	) -> Result<I2pDatagramSocket, Error> {
 		unimplemented!();
 	}
@@ -178,14 +178,14 @@ impl I2pDatagramSocket {
 	/// socket.connect("127.0.0.1:8080").expect("connect function failed");
 	/// ```
 	pub fn connect<A: ToI2pSocketAddrs>(&self, addr: A) -> Result<(), Error> {
-		self.connect_via(DEFAULT_API, addr, &SAMOptions::default())
+		self.connect_via(DEFAULT_API, addr, SAMOptions::default())
 	}
 
 	pub fn connect_via<A: ToSocketAddrs, B: ToI2pSocketAddrs>(
 		&self,
 		sam_addr: A,
 		addr: B,
-		options: &SAMOptions,
+		options: SAMOptions,
 	) -> Result<(), Error> {
 		super::each_i2p_addr(sam_addr, addr, options, |_sam_addr, _addr, _opts| unimplemented!())
 	}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -17,16 +17,16 @@ mod test;
 fn each_i2p_addr<A: ToSocketAddrs, B: ToI2pSocketAddrs, F, T>(
 	sam_addr: A,
 	addr: B,
-	opts: &SAMOptions,
+	opts: SAMOptions,
 	mut f: F,
 ) -> Result<T, Error>
 where
-	F: FnMut(&SocketAddr, &I2pSocketAddr, &SAMOptions) -> Result<T, Error>,
+	F: FnMut(&SocketAddr, &I2pSocketAddr, SAMOptions) -> Result<T, Error>,
 {
 	let mut last_err = None;
 	for addr in addr.to_socket_addrs()? {
 		for sam_addr in sam_addr.to_socket_addrs()? {
-			match f(&sam_addr, &addr, opts) {
+			match f(&sam_addr, &addr, opts.clone()) {
 				Ok(l) => return Ok(l),
 				Err(e) => last_err = Some(e),
 			}
@@ -35,13 +35,13 @@ where
 	Err(last_err.unwrap_or(ErrorKind::UnresolvableAddress.into()))
 }
 
-fn each_addr<A: ToSocketAddrs, F, T>(sam_addr: A, opts: &SAMOptions, mut f: F) -> Result<T, Error>
+fn each_addr<A: ToSocketAddrs, F, T>(sam_addr: A, opts: SAMOptions, mut f: F) -> Result<T, Error>
 where
-	F: FnMut(&SocketAddr, &SAMOptions) -> Result<T, Error>,
+	F: FnMut(&SocketAddr, SAMOptions) -> Result<T, Error>,
 {
 	let mut last_err = None;
 	for sam_addr in sam_addr.to_socket_addrs()? {
-		match f(&sam_addr, opts) {
+		match f(&sam_addr, opts.clone()) {
 			Ok(l) => return Ok(l),
 			Err(e) => last_err = Some(e),
 		}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,10 +1,11 @@
 use crate::error::{Error, ErrorKind};
+use crate::sam_options::SAMOptions;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 pub use self::addr::{I2pSocketAddr, ToI2pSocketAddrs};
 pub use self::datagram::I2pDatagramSocket;
 pub use self::i2p::I2pAddr;
-pub use self::streaming::{I2pListener, I2pStream};
+pub use self::streaming::{I2pListenerBuilder, I2pListener, I2pStream};
 
 mod addr;
 mod datagram;
@@ -16,15 +17,16 @@ mod test;
 fn each_i2p_addr<A: ToSocketAddrs, B: ToI2pSocketAddrs, F, T>(
 	sam_addr: A,
 	addr: B,
+	opts: &SAMOptions,
 	mut f: F,
 ) -> Result<T, Error>
 where
-	F: FnMut(&SocketAddr, &I2pSocketAddr) -> Result<T, Error>,
+	F: FnMut(&SocketAddr, &I2pSocketAddr, &SAMOptions) -> Result<T, Error>,
 {
 	let mut last_err = None;
 	for addr in addr.to_socket_addrs()? {
 		for sam_addr in sam_addr.to_socket_addrs()? {
-			match f(&sam_addr, &addr) {
+			match f(&sam_addr, &addr, opts) {
 				Ok(l) => return Ok(l),
 				Err(e) => last_err = Some(e),
 			}
@@ -33,13 +35,13 @@ where
 	Err(last_err.unwrap_or(ErrorKind::UnresolvableAddress.into()))
 }
 
-fn each_addr<A: ToSocketAddrs, F, T>(sam_addr: A, mut f: F) -> Result<T, Error>
+fn each_addr<A: ToSocketAddrs, F, T>(sam_addr: A, opts: &SAMOptions, mut f: F) -> Result<T, Error>
 where
-	F: FnMut(&SocketAddr) -> Result<T, Error>,
+	F: FnMut(&SocketAddr, &SAMOptions) -> Result<T, Error>,
 {
 	let mut last_err = None;
 	for sam_addr in sam_addr.to_socket_addrs()? {
-		match f(&sam_addr) {
+		match f(&sam_addr, opts) {
 			Ok(l) => return Ok(l),
 			Err(e) => last_err = Some(e),
 		}

--- a/src/net/streaming.rs
+++ b/src/net/streaming.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use crate::error::{Error, ErrorKind};
 use crate::net::{I2pAddr, I2pSocketAddr, ToI2pSocketAddrs};
 use crate::sam::{Session, StreamConnect, StreamForward, DEFAULT_API};
+use crate::sam_options::SAMOptions;
 
 /// A structure which represents an I2P stream between a local socket and a
 /// remote socket.
@@ -74,7 +75,7 @@ impl I2pStream {
 	/// }
 	/// ```
 	pub fn connect<A: ToI2pSocketAddrs>(addr: A) -> Result<I2pStream, Error> {
-		I2pStream::connect_via(DEFAULT_API, addr)
+		I2pStream::connect_via(DEFAULT_API, addr, &SAMOptions::default())
 	}
 
 	/// Same as `connect` but reuses an existing SAM session.
@@ -92,12 +93,13 @@ impl I2pStream {
 	pub fn connect_via<A: ToSocketAddrs, B: ToI2pSocketAddrs>(
 		sam_addr: A,
 		addr: B,
+		options: &SAMOptions,
 	) -> Result<I2pStream, Error> {
-		super::each_i2p_addr(sam_addr, addr, I2pStream::connect_addr).map_err(|e| e.into())
+		super::each_i2p_addr(sam_addr, addr, options, I2pStream::connect_addr).map_err(|e| e.into())
 	}
 
-	fn connect_addr(sam_addr: &SocketAddr, addr: &I2pSocketAddr) -> Result<I2pStream, Error> {
-		let stream = StreamConnect::new(sam_addr, &addr.dest().string(), addr.port())?;
+	fn connect_addr(sam_addr: &SocketAddr, addr: &I2pSocketAddr, options: &SAMOptions) -> Result<I2pStream, Error> {
+		let stream = StreamConnect::new(sam_addr, &addr.dest().string(), addr.port(), options)?;
 
 		Ok(I2pStream { inner: stream })
 	}
@@ -295,11 +297,11 @@ impl I2pListener {
 	}
 
 	pub fn bind_via<A: ToSocketAddrs>(sam_addr: A) -> Result<I2pListener, Error> {
-		super::each_addr(sam_addr, I2pListener::bind_addr).map_err(|e| e.into())
+		super::each_addr(sam_addr, &SAMOptions::default(), I2pListener::bind_addr).map_err(|e| e.into())
 	}
 
-	fn bind_addr(sam_addr: &SocketAddr) -> Result<I2pListener, Error> {
-		let forward = StreamForward::new(sam_addr)?;
+	fn bind_addr(sam_addr: &SocketAddr, options: &SAMOptions) -> Result<I2pListener, Error> {
+		let forward = StreamForward::new(sam_addr, options)?;
 		Ok(I2pListener { forward })
 	}
 
@@ -395,5 +397,105 @@ impl<'a> Iterator for Incoming<'a> {
 	type Item = Result<I2pStream, Error>;
 	fn next(&mut self) -> Option<Result<I2pStream, Error>> {
 		Some(self.listener.accept().map(|p| p.0))
+	}
+}
+
+
+/// A helper struct for creating `I2pListener`s.
+///
+/// # Examples
+///
+/// ```no_run
+/// use i2p::net::{I2pListenerBuilder, I2pStream};
+///
+/// let listener = I2pListenerBuilder::new().build()?;
+///
+/// fn handle_client(stream: I2pStream) {
+///     // ...
+/// }
+///
+/// // accept connections and process them serially
+/// for stream in listener.incoming() {
+///     match stream {
+///         Ok(stream) => {
+///             handle_client(stream);
+///         }
+///         Err(e) => { /* connection failed */ }
+///     }
+/// }
+/// ```
+pub struct I2pListenerBuilder {
+	session: Option<Session>,
+	addrs: Vec<SocketAddr>,
+	options: SAMOptions,
+}
+
+impl Default for I2pListenerBuilder {
+	fn default() -> Self {
+		I2pListenerBuilder {
+			session: None,
+			addrs: vec![],
+			options: Default::default()
+		}
+	}
+}
+
+impl I2pListenerBuilder {
+
+	/// Build an `I2pListener` and bind to socket addresses using previously
+	/// defined settings.
+	/// 
+	/// If none of `with_session`, `with_addr` or `with_addrs` were called, the
+	/// listener will bind to `crate::sam::DEFAULT_API`.
+	/// 
+	/// If `with_options` was not called, defaults to `SAMOptions::default()`
+	/// 
+	/// If `with_session` was called, all other settings will be ignored.
+	pub fn build(mut self) -> Result<I2pListener, Error> {
+		if let Some(s) = self.session {
+			Ok(I2pListener {
+				forward: StreamForward::with_session(&s)?
+			})
+		}
+		else {
+			// Default to DEFAULT_API if no socket address has been set manually
+			if self.addrs.len() == 0 {
+				self.addrs.extend(ToSocketAddrs::to_socket_addrs(DEFAULT_API)?);
+			}
+			super::each_addr(
+				self.addrs.as_slice(), 
+				&self.options, 
+				I2pListener::bind_addr
+			).map_err(|e| e.into())
+		}
+	}
+
+	/// Makes this builder recreate an I2pListener from the specified session.
+	/// According to the SAMv3 protocol, SAM options can only be set upon
+	/// session creation. Therefore, `I2pListenerBuilder::build(...)` will
+	/// ignore any options set using `with_options` if recreating a listener
+	/// using a previous session.
+	pub fn with_session(mut self, session: Session) -> Self {
+		self.session = Some(session);
+		self
+	}
+
+	/// Add `address` to the list of socket addresses to bind to
+	pub fn with_addr(mut self, address: SocketAddr) -> Self {
+		self.addrs.push(address);
+		self
+	}
+
+	/// Add all addresses derived from `addresses` to the list of socket
+	/// addresses to bind to
+	pub fn with_addrs<A: ToSocketAddrs>(mut self, addresses: A) -> Result<Self, Error> {
+		self.addrs.extend(addresses.to_socket_addrs()?);
+		Ok(self)
+	}
+
+	/// Use the SAMOptions specified when building the `I2pListener`
+	pub fn with_options(mut self, opts: SAMOptions) -> Self {
+		self.options = opts;
+		self
 	}
 }

--- a/src/net/streaming.rs
+++ b/src/net/streaming.rs
@@ -75,7 +75,7 @@ impl I2pStream {
 	/// }
 	/// ```
 	pub fn connect<A: ToI2pSocketAddrs>(addr: A) -> Result<I2pStream, Error> {
-		I2pStream::connect_via(DEFAULT_API, addr, &SAMOptions::default())
+		I2pStream::connect_via(DEFAULT_API, addr, SAMOptions::default())
 	}
 
 	/// Same as `connect` but reuses an existing SAM session.
@@ -93,12 +93,12 @@ impl I2pStream {
 	pub fn connect_via<A: ToSocketAddrs, B: ToI2pSocketAddrs>(
 		sam_addr: A,
 		addr: B,
-		options: &SAMOptions,
+		options: SAMOptions,
 	) -> Result<I2pStream, Error> {
 		super::each_i2p_addr(sam_addr, addr, options, I2pStream::connect_addr).map_err(|e| e.into())
 	}
 
-	fn connect_addr(sam_addr: &SocketAddr, addr: &I2pSocketAddr, options: &SAMOptions) -> Result<I2pStream, Error> {
+	fn connect_addr(sam_addr: &SocketAddr, addr: &I2pSocketAddr, options: SAMOptions) -> Result<I2pStream, Error> {
 		let stream = StreamConnect::new(sam_addr, &addr.dest().string(), addr.port(), options)?;
 
 		Ok(I2pStream { inner: stream })
@@ -297,10 +297,10 @@ impl I2pListener {
 	}
 
 	pub fn bind_via<A: ToSocketAddrs>(sam_addr: A) -> Result<I2pListener, Error> {
-		super::each_addr(sam_addr, &SAMOptions::default(), I2pListener::bind_addr).map_err(|e| e.into())
+		super::each_addr(sam_addr, SAMOptions::default(), I2pListener::bind_addr).map_err(|e| e.into())
 	}
 
-	fn bind_addr(sam_addr: &SocketAddr, options: &SAMOptions) -> Result<I2pListener, Error> {
+	fn bind_addr(sam_addr: &SocketAddr, options: SAMOptions) -> Result<I2pListener, Error> {
 		let forward = StreamForward::new(sam_addr, options)?;
 		Ok(I2pListener { forward })
 	}
@@ -464,7 +464,7 @@ impl I2pListenerBuilder {
 			}
 			super::each_addr(
 				self.addrs.as_slice(), 
-				&self.options, 
+				self.options, 
 				I2pListener::bind_addr
 			).map_err(|e| e.into())
 		}

--- a/src/sam.rs
+++ b/src/sam.rs
@@ -177,7 +177,7 @@ impl Session {
 		destination: &str,
 		nickname: &str,
 		style: SessionStyle,
-		options: SAMOptions,
+		options: &SAMOptions,
 	) -> Result<Session, Error> {
 		let mut sam = SamConnection::connect(sam_addr)?;
 		let create_session_msg = format!(
@@ -207,25 +207,26 @@ impl Session {
 	pub fn from_destination<A: ToSocketAddrs>(
 		sam_addr: A,
 		destination: &str,
+		options: &SAMOptions,
 	) -> Result<Session, Error> {
 		Self::create(
 			sam_addr,
 			destination,
 			&nickname(),
 			SessionStyle::Stream,
-			SAMOptions::default(),
+			options,
 		)
 	}
 
 	/// Convenience constructor to create a new transient session with an
 	/// auto-generated nickname.
-	pub fn transient<A: ToSocketAddrs>(sam_addr: A) -> Result<Session, Error> {
+	pub fn transient<A: ToSocketAddrs>(sam_addr: A, options: &SAMOptions) -> Result<Session, Error> {
 		Self::create(
 			sam_addr,
 			"TRANSIENT",
 			&nickname(),
 			SessionStyle::Stream,
-			SAMOptions::default(),
+			options,
 		)
 	}
 
@@ -260,8 +261,9 @@ impl StreamConnect {
 		sam_addr: A,
 		destination: &str,
 		port: u16,
+		options: &SAMOptions,
 	) -> Result<StreamConnect, Error> {
-		let session = Session::transient(sam_addr)?;
+		let session = Session::transient(sam_addr, options)?;
 		Self::with_session(&session, destination, port)
 	}
 
@@ -353,9 +355,9 @@ pub struct StreamForward {
 }
 
 impl StreamForward {
-	pub fn new<A: ToSocketAddrs>(sam_addr: A) -> Result<StreamForward, Error> {
+	pub fn new<A: ToSocketAddrs>(sam_addr: A, options: &SAMOptions) -> Result<StreamForward, Error> {
 		Ok(StreamForward {
-			session: Session::transient(sam_addr)?,
+			session: Session::transient(sam_addr, options)?,
 		})
 	}
 

--- a/src/sam.rs
+++ b/src/sam.rs
@@ -177,7 +177,7 @@ impl Session {
 		destination: &str,
 		nickname: &str,
 		style: SessionStyle,
-		options: &SAMOptions,
+		options: SAMOptions,
 	) -> Result<Session, Error> {
 		let mut sam = SamConnection::connect(sam_addr)?;
 		let create_session_msg = format!(
@@ -207,7 +207,7 @@ impl Session {
 	pub fn from_destination<A: ToSocketAddrs>(
 		sam_addr: A,
 		destination: &str,
-		options: &SAMOptions,
+		options: SAMOptions,
 	) -> Result<Session, Error> {
 		Self::create(
 			sam_addr,
@@ -220,7 +220,7 @@ impl Session {
 
 	/// Convenience constructor to create a new transient session with an
 	/// auto-generated nickname.
-	pub fn transient<A: ToSocketAddrs>(sam_addr: A, options: &SAMOptions) -> Result<Session, Error> {
+	pub fn transient<A: ToSocketAddrs>(sam_addr: A, options: SAMOptions) -> Result<Session, Error> {
 		Self::create(
 			sam_addr,
 			"TRANSIENT",
@@ -261,7 +261,7 @@ impl StreamConnect {
 		sam_addr: A,
 		destination: &str,
 		port: u16,
-		options: &SAMOptions,
+		options: SAMOptions,
 	) -> Result<StreamConnect, Error> {
 		let session = Session::transient(sam_addr, options)?;
 		Self::with_session(&session, destination, port)
@@ -355,7 +355,7 @@ pub struct StreamForward {
 }
 
 impl StreamForward {
-	pub fn new<A: ToSocketAddrs>(sam_addr: A, options: &SAMOptions) -> Result<StreamForward, Error> {
+	pub fn new<A: ToSocketAddrs>(sam_addr: A, options: SAMOptions) -> Result<StreamForward, Error> {
 		Ok(StreamForward {
 			session: Session::transient(sam_addr, options)?,
 		})

--- a/src/session_watcher.rs
+++ b/src/session_watcher.rs
@@ -90,7 +90,7 @@ impl SamSessionWatcher {
             destination,
             nickname,
             session_style,
-            &opts.clone(), 
+            opts.clone(), 
         )?; 
         let listener = I2pListener::bind_with_session(&session)?; 
         Ok((session, listener))

--- a/src/session_watcher.rs
+++ b/src/session_watcher.rs
@@ -90,7 +90,7 @@ impl SamSessionWatcher {
             destination,
             nickname,
             session_style,
-            opts.clone(), 
+            &opts.clone(), 
         )?; 
         let listener = I2pListener::bind_with_session(&session)?; 
         Ok((session, listener))


### PR DESCRIPTION
## Primary goal
As of now, setting the `SAMOptions`  of an `I2pListener` is not very convenient, and not supported by the primary constructing functions of `I2pListener`. This PR introduces an `I2pListenerBuilder`, which tries to fix this.

## Binding to addresses
Also, currently there are three functions (`bind`, `bind_via` and `bind_addr`) which bind the listener to some address, but the distinction is not quite clear. The builder addresses this by only exposing the functions `with_addr` (exactly one already parsed `SocketAddr`) and `with_addrs` (everything that may or may not resolve to one or more `SocketAddr`s - hence the `Result` return type). From my point of view, this is easier to understand for the users and as a side effect also allows binding to exactly two `SocketAddr`s by just calling `with_addr` twice.

## Changes to existing code
Changing some existing function signatures was necessary, since the `SAMOptions` were previously set to `default()` "deep in the code". This parameter is now passed down from `I2pListener` and `I2pDatagramSocket` functions. To leave the "simplest way" of instanciating a listener or datagram socket as simple as is, those function signatures weren't changed. They use the default `SAMOptions`.

## Future work
- A builder could also be implemented for the `I2pDatagramSocket`
- Depending on the opinion of the maintainer and users of this library, the currently used `bind` functions of `I2pListener` could also be removed as they are redundant and (from my very personal perspective) less easy-to-use and harder to understand.